### PR TITLE
SVG function update. If SVG has named parent

### DIFF
--- a/WebExtension/checks/_common.scss
+++ b/WebExtension/checks/_common.scss
@@ -44,6 +44,7 @@
   place-content: flex-start flex-start !important;
   padding: 0.5em !important;
   position: relative !important;
+  z-index: 2147483647 !important;
 }
 
 /* Styling for a common accessibility message */

--- a/WebExtension/checks/svg-decorative/decoration-svg-remove.ts
+++ b/WebExtension/checks/svg-decorative/decoration-svg-remove.ts
@@ -2,6 +2,7 @@
 
 removeInjectedDivs([
   "neutral-message-9927845",
+  'warning-message-9927845',
   "warning-9927845",
   "invalid-message-9927845",
   "svg-hidden-ancestor-882726654"

--- a/WebExtension/checks/svg-decorative/decoration-svg.ts
+++ b/WebExtension/checks/svg-decorative/decoration-svg.ts
@@ -1,72 +1,115 @@
 "use strict";
 
 function checkSvgDecorative() {
-    const svgElements = document.querySelectorAll("svg");
-    const decorativeSvgClass = "neutral-message-9927845";
-    const decorativeSvgWithNameClass = "neutral-message-9927845";
+  const svgElements = document.querySelectorAll("svg");
+  const decorativeSvgClass = "neutral-message-9927845";
+  const decorativeSvgWithNameClass = "neutral-message-9927845";
 
-    for (const svgElement of svgElements) {
-        const ariaHidden = svgElement.getAttribute("aria-hidden");
-        const ariaLabel = svgElement.getAttribute("aria-label");
-        const accessibleNameMissing = !ariaLabel || ariaLabel.trim() === "";
-        const accessibleNamePresent = ariaLabel && ariaLabel.trim() !== "";
+  for (const svgElement of svgElements) {
+    const ariaHidden = svgElement.getAttribute("aria-hidden");
+    const ariaLabel = svgElement.getAttribute("aria-label");
+    const accessibleNameMissing = !ariaLabel || ariaLabel.trim() === "";
+    const accessibleNamePresent = ariaLabel && ariaLabel.trim() !== "";
 
-        if (ariaHidden === "true") {
-            if (accessibleNameMissing) {
-                const message = "This SVG is marked as decorative with 'aria-hidden true'";
-                createChildMessageDiv(svgElement, decorativeSvgClass, message);
-            } else if (accessibleNamePresent) {
-                const message = "This SVG has an accessible name but is marked as decorative with 'aria-hidden true'";
-                createChildMessageDiv(svgElement, decorativeSvgWithNameClass, message);
-            }
-        }
+    if (ariaHidden === "true") {
+      if (accessibleNameMissing) {
+        const message = "This SVG is marked as decorative with 'aria-hidden true'";
+        createChildMessageDiv(svgElement, decorativeSvgClass, message);
+      } else if (accessibleNamePresent) {
+        const message = "This SVG has an accessible name but is marked as decorative with 'aria-hidden true'";
+        createChildMessageDiv(svgElement, decorativeSvgWithNameClass, message);
+      }
     }
+  }
 }
 
 checkSvgDecorative();
 
 function checkSvgAccessibleNamesDecorative() {
-    const svgElements = document.querySelectorAll("svg");
-    const hiddenAncestorClass = "svg-hidden-ancestor-882726654";
-    const decorativeAncestorClass = "svg--decorativeAncestor-882726654";
+  const svgElements = document.querySelectorAll("svg");
+  const hiddenAncestorClass = "svg-hidden-ancestor-882726654";
+  const decorativeAncestorClass = "svg--decorativeAncestor-882726654";
+  const imgRoleWithLabelClass = "warning-message-9927845";
 
-    function checkAncestors(element: Element) {
-        let currentElement = element;
+  function checkAncestors(element: Element) {
+    let currentElement = element;
 
-        while (currentElement.parentElement) {
-            currentElement = currentElement.parentElement;
+    while (currentElement.parentElement) {
+      currentElement = currentElement.parentElement;
 
-            const tagName = currentElement.tagName.toLowerCase();
-            const role = currentElement.getAttribute("role");
+      const tagName = currentElement.tagName.toLowerCase();
+      const roleAttr = currentElement.getAttribute("role");
+      const accessibleName = currentElement.getAttribute("aria-label") || currentElement.textContent || "";
 
-            if (currentElement.getAttribute("aria-hidden") === "true") {
-                return { element: currentElement, isHidden: true };
-            }
-            if (role === "none" || role === "presentation") {
-                return { element: currentElement, isDecorative: true };
-            }
-        }
+      if (currentElement.getAttribute("aria-hidden") === "true") {
+        return {
+          element: currentElement,
+          isHidden: true,
+          accessibleName: accessibleName.trim(),
+        };
+      }
+      if (roleAttr === "none" || roleAttr === "presentation") {
+        return {
+          element: currentElement,
+          isDecorative: true,
+          accessibleName: accessibleName.trim(),
+        };
+      }
 
-        return null;
+      if (tagName === "a" || tagName === "button" || roleAttr === "link" || roleAttr === "button") {
+        return {
+          element: currentElement,
+          accessibleName: accessibleName.trim(),
+          role: roleAttr,
+        };
+      }
     }
 
-    for (const svgElement of svgElements) {
-        const svgText = svgElement.getAttribute("aria-label");
-        const hiddenElement = svgElement.getAttribute("aria-hidden");
-        const role = svgElement.getAttribute("role");
-        const accessibleNameMissing = !svgText || svgText.trim() === "";
-        const ancestorCheck = checkAncestors(svgElement);
+    return null;
+  }
 
-        if (ancestorCheck && ancestorCheck.isHidden) {
-            const message = "An ancestor element of this SVG has 'aria-hidden' set to 'true'.";
-            createChildMessageDiv(svgElement, hiddenAncestorClass, message);
-        }
+  for (const svgElement of svgElements) {
+    const svgText = svgElement.getAttribute("aria-label");
+    const hiddenElement = svgElement.getAttribute("aria-hidden");
+    const role = svgElement.getAttribute("role");
+    const ancestorCheck = checkAncestors(svgElement);
 
-        if (ancestorCheck && ancestorCheck.isDecorative) {
-            const message = "This SVG is decorative. An ancestor element of this SVG has 'role none or role presentation'.";
-            createChildMessageDiv(svgElement, decorativeAncestorClass, message);
-        }
+    let messageGenerated = false; // Flag to track if the new function generates a message
+
+    // New function to check if the parent of the SVG has an accessible name
+    if (ancestorCheck?.accessibleName) {
+      const parentRole = ancestorCheck.role ?? ancestorCheck.element.tagName.toLowerCase();
+      const parentName = ancestorCheck.accessibleName;
+      if (role === "img" && !svgText && hiddenElement !== "true") {
+        const message = `Warning SVG has parent with role ${parentRole} has an accessible name "${parentName}". This SVG should be marked as decorative with aria-hidden="true".`;
+        createChildMessageDiv(svgElement, imgRoleWithLabelClass, message);
+        messageGenerated = true;
+      } else if (role === "img" && svgText && hiddenElement !== "true") {
+        const message = `Warning SVG has parent with role ${parentRole} has accessible name "${parentName}". Check if this SVG should be marked as decorative with aria-hidden="true".`;
+        createChildMessageDiv(svgElement, imgRoleWithLabelClass, message);
+        messageGenerated = true;
+      } else if (!role && !svgText && hiddenElement !== "true") {
+        const message = `Warning SVG has parent with role ${parentRole} has an accessible name "${parentName}". This SVG should be marked as decorative with aria-hidden="true".`;
+        createChildMessageDiv(svgElement, imgRoleWithLabelClass, message);
+        messageGenerated = true;
+      }
     }
+
+    // Skip other checks if the new function has generated a message
+    if (messageGenerated) {
+      continue;
+    }
+
+    if (ancestorCheck && ancestorCheck.isHidden) {
+      const message = "An ancestor element of this SVG has 'aria-hidden' set to 'true'.";
+      createChildMessageDiv(svgElement, hiddenAncestorClass, message);
+    }
+
+    if (ancestorCheck && ancestorCheck.isDecorative) {
+      const message = "This SVG is decorative. An ancestor element of this SVG has 'role none or role presentation'.";
+      createChildMessageDiv(svgElement, decorativeAncestorClass, message);
+    }
+  }
 }
 
 checkSvgAccessibleNamesDecorative();

--- a/WebExtension/checks/svg-decorative/decorative-svg.scss
+++ b/WebExtension/checks/svg-decorative/decorative-svg.scss
@@ -1,6 +1,13 @@
 @import '../common';
 @import '../scss-partial-overflow-hidden-hack';
 
+@mixin common-style($backgroundColor, $borderColor, $textColor) {
+  background-color: $backgroundColor !important;
+  color: $textColor !important;
+  border: 3px solid $borderColor !important;
+  min-width:10em;
+}
+
 @mixin decorative-svg($backgroundColor, $borderColor, $textColor) {
   @include important-styles(
     (
@@ -40,6 +47,16 @@
     ),
     true
   );
+}
+
+.warning-message-9927845 {
+  @include common-style(
+    var(--warning-background),
+    var(--warning-border),
+    var(--warning-text)
+  );
+
+  @include messageDisplayStyles;
 }
 
 .invalid-message-9927845 {

--- a/WebExtension/checks/svg-name/show-svg-name.ts
+++ b/WebExtension/checks/svg-name/show-svg-name.ts
@@ -190,6 +190,32 @@ function checkSvgAccessibleNames() {
       continue; // Skip SVGs that are explicitly hidden
     }
 
+    let messageGenerated = false; // Flag to track if the new function generates a message
+
+    // New function to check if the parent of the SVG has an accessible name
+    if (ancestorCheck?.accessibleName) {
+      const parentRole = ancestorCheck.role ?? ancestorCheck.element.tagName.toLowerCase();
+      const parentName = ancestorCheck.accessibleName;
+      if (role === "img" && !name && hiddenElement !== "true") {
+        const message = `Warning SVG has parent with role ${parentRole} has an accessible name "${parentName}". This SVG should be marked as decorative with aria-hidden="true".`;
+        createChildMessageDiv(svgElement, imgRoleWithLabelClass, message);
+        messageGenerated = true;
+      } else if (role === "img" && name && hiddenElement !== "true") {
+        const message = `Warning SVG has parent with role ${parentRole} has accessible name "${parentName}". Check if this SVG should be marked as decorative with aria-hidden="true".`;
+        createChildMessageDiv(svgElement, imgRoleWithLabelClass, message);
+        messageGenerated = true;
+      } else if (!role && !name && hiddenElement !== "true") {
+        const message = `Warning SVG has parent with role ${parentRole} has an accessible name "${parentName}". This SVG should be marked as decorative with aria-hidden="true".`;
+        createChildMessageDiv(svgElement, imgRoleWithLabelClass, message);
+        messageGenerated = true;
+      }
+    }
+
+    // Skip other checks if the new function has generated a message
+    if (messageGenerated) {
+      continue;
+    }
+
     if (name) {
       const nameMessage = `Valid The SVG is named using ${method}: "${name}".`;
       createChildMessageDiv(svgElement, showSvgTextClass, nameMessage);


### PR DESCRIPTION
Discovered on telstra.com.au where svg not named with role image has parent of button with an aria-label

Reporting messages when the parent of the SVG has an accessible name

 - SVG has role img, no accessible name, not hidden via aria-hidden true. Message : The parent with role X has an accessible name Y. This SVG should be marked as decorative with aria hidden true
 - SVG has role img, an accessible name, not hidden via aria-hidden true. Message : The parent with role X has accessible name Y. Check if this SVG should be marked as decorative with aria hidden true.
 - SVG has no role img, no accessible name, not hidden via aria-hidden true. Message : The parent with role X has an accessible name Y. This SVG should be marked as decorative with aria hidden true.