### PR TITLE
Add firefox support

### DIFF
--- a/WebExtension/extension/ui/js/error.handling.ts
+++ b/WebExtension/extension/ui/js/error.handling.ts
@@ -7,6 +7,7 @@ export async function loadOptionsObject() {
     let rawResponse: any;
     const request = new InternalRequest();
     request.type = "getSettings";
+    request.values = [];
     try {
       rawResponse = await chrome.tabs.sendMessage(await getTabId(), request, {
         frameId: 0,

--- a/WebExtension/manifest.json
+++ b/WebExtension/manifest.json
@@ -31,6 +31,7 @@
     ],
     
     "background": {
-        "scripts": ["extension/service-worker.js"]
+        "scripts": ["extension/service-worker.js"],
+        "service_worker": "extension/service-worker.js"
     }
 }

--- a/WebExtension/manifest.json
+++ b/WebExtension/manifest.json
@@ -31,6 +31,6 @@
     ],
     
     "background": {
-        "service_worker": "extension/service-worker.js"
+        "scripts": ["extension/service-worker.js"]
     }
 }


### PR DESCRIPTION
Adds firefox support. A few notes:
- Firefox does not like version numbers with leading zeroes. So `06.04` would need to become `6.4` for example.
- Chrome will warn about the `scripts` key in `background`, but will still install the extension. Likewise, Firefox is not a fan of the `service_worker` key, but will still install the extension.
- Firefox also warns about the `version_name` key as unrecognized, but we can ignore this.
- For the extension to work in Firefox, right now you'll have to go to `about:addons` and explicitly give it permission to access all domains. We could potentially get around this by adding our own prompt to the user, as explained on [mdn](https://extensionworkshop.com/documentation/develop/manifest-v3-migration-guide/). This is probably good to do anyway, as ManifestV3 does not explictly require the browser to grant host permissions automatically. Since that's a larger task and hits multiple browsers, I've left it off this PR, but could open another PR later with that functionality. Or I could add it to this one if that's preferred.

I chose not to create two separate manifests because that seems like more trouble than it's worth, but I could do that if you think that is a better option.